### PR TITLE
chore: add environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Sanity project ID used by the frontend
+NEXT_PUBLIC_SANITY_PROJECT_ID=
+
+# Sanity dataset name (e.g., 'production')
+NEXT_PUBLIC_SANITY_DATASET=
+
+# Date-based Sanity API version
+NEXT_PUBLIC_SANITY_API_VERSION=
+
+# Optional read token for fetching private data
+SANITY_READ_TOKEN=
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- document Sanity environment variables in `.env.example`
- allow tracking `.env.example` via `.gitignore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module 'sanity/cli' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ddaf02148324add7f684dede84d7