### PR TITLE
feat: enable sanity vision tool

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,11 +1,12 @@
 import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
+import {visionTool} from '@sanity/vision'
 import project from './src/sanity/schemaTypes/project'
 import {projectId, dataset} from './src/sanity/env'
 
 export default defineConfig({
   projectId,
   dataset,
-  plugins: [deskTool()],
+  plugins: [deskTool(), visionTool()],
   schema: {types: [project]},
 })


### PR DESCRIPTION
## Summary
- add Sanity Vision tool to studio configuration

## Testing
- `npm run check` *(fails: Cannot find module 'sanity/cli' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ddadeb9c8324920e8411ea44a924