### PR TITLE
Enable custom Sanity desk structure

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -2,10 +2,11 @@ import {defineConfig} from 'sanity'
 import {deskTool} from 'sanity/desk'
 import project from './src/sanity/schemaTypes/project'
 import {projectId, dataset} from './src/sanity/env'
+import {structure} from './src/sanity/structure'
 
 export default defineConfig({
   projectId,
   dataset,
-  plugins: [deskTool()],
+  plugins: [deskTool({structure})],
   schema: {types: [project]},
 })


### PR DESCRIPTION
## Summary
- wire up `structure` to `deskTool` in Sanity config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module 'sanity' and other type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ddaca6248324a2e1b3d8d8b5c0f2