### PR TITLE
Align project types with Sanity schema

### DIFF
--- a/src/app/(marketing)/projects/page.tsx
+++ b/src/app/(marketing)/projects/page.tsx
@@ -6,7 +6,7 @@ import type {Project} from '@/types/project';
 import {Pin, ChevronRight, Search} from '@/components/icons';
 import {getProjects} from '@/sanity/queries';
 
-type Category = Project['category'];
+type PropertyType = Project['propertyType'];
 
 export default async function ProjectsPage() {
   const projects = await getProjects();
@@ -16,8 +16,8 @@ export default async function ProjectsPage() {
 function ProjectsPageClient({projects}: {projects: Project[]}) {
   'use client';
 
-  const categories = useMemo<Category[]>(
-    () => Array.from(new Set(projects.map(p => p.category))) as Category[],
+  const propertyTypes = useMemo<PropertyType[]>(
+    () => Array.from(new Set(projects.map(p => p.propertyType))) as PropertyType[],
     [projects],
   );
   const locations = useMemo<string[]>(
@@ -26,23 +26,23 @@ function ProjectsPageClient({projects}: {projects: Project[]}) {
   );
 
   const [q, setQ] = useState('');
-  const [category, setCategory] = useState<'All' | Category>('All');
+  const [propertyType, setPropertyType] = useState<'All' | PropertyType>('All');
   const [location, setLocation] = useState<string>('All');
 
   const filtered = useMemo<Project[]>(() => {
     return projects.filter(p => {
-      const byCat = category === 'All' ? true : p.category === category;
+      const byType = propertyType === 'All' ? true : p.propertyType === propertyType;
       const byLoc = location === 'All' ? true : p.location === location;
       const byQ =
         q.trim() === ''
           ? true
-          : [p.title, p.location, p.category]
+          : [p.title, p.location, p.propertyType]
               .join(' ')
               .toLowerCase()
               .includes(q.toLowerCase());
-      return byCat && byLoc && byQ;
+      return byType && byLoc && byQ;
     });
-  }, [category, location, q, projects]);
+  }, [propertyType, location, q, projects]);
 
   return (
     <main className="min-h-screen bg-white">
@@ -67,16 +67,16 @@ function ProjectsPageClient({projects}: {projects: Project[]}) {
 
           {/* Right selects */}
           <div className="flex items-center gap-4">
-            {/* Category */}
+            {/* Property Type */}
             <div className="relative w-1/2">
               <select
-                value={category}
-                onChange={e => setCategory(e.target.value as 'All' | Category)}
+                value={propertyType}
+                onChange={e => setPropertyType(e.target.value as 'All' | PropertyType)}
                 className="h-11 w-full appearance-none rounded-lg border border-black/10 bg-white pr-9 pl-3 text-sm text-neutral-800 outline-none focus:ring-2 focus:ring-black/10"
-                aria-label="Project category"
+                aria-label="Property type"
               >
-                <option value="All">Project</option>
-                {categories.map(c => (
+                <option value="All">Property Type</option>
+                {propertyTypes.map(c => (
                   <option key={c} value={c}>
                     {c}
                   </option>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -17,7 +17,7 @@ export default function ProjectCard({ project }: { project: Project }) {
       </div>
       <div className="space-y-2 p-4">
         <div className="text-xs tracking-wide text-neutral-500 uppercase">
-          {project.category} · {project.location}
+          {project.propertyType} · {project.location}
         </div>
         <h3 className="text-lg font-semibold">{project.title}</h3>
         <p className="line-clamp-2 text-sm text-neutral-600">

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -2,30 +2,31 @@ import {groq} from 'next-sanity'
 import type {Project} from '@/types/project'
 import {client} from './lib/client'
 
-export const projectsQuery = groq`
-  *[_type == "project"]{
-    "slug": slug.current,
-    "title": name,
-    "location": coalesce(location, ""),
-    "category": coalesce(propertyType, ""),
-    "thumbnail": image1.asset->url,
-    "hero": image1.asset->url,
-    "summary": coalesce(description, ""),
-    "description": coalesce(description, "")
-  }
+const baseFields = groq`
+  "slug": slug.current,
+  "title": name,
+  location,
+  propertyType,
+  bedrooms,
+  developer,
+  startingPriceAED,
+  sizeRange,
+  listingUrl,
+  "thumbnail": image1.asset->url,
+  "hero": image1.asset->url,
+  "summary": coalesce(description, ""),
+  description,
+  "image1": {"url": image1.asset->url, "alt": coalesce(image1.alt, "")},
+  "image2": {"url": image2.asset->url, "alt": coalesce(image2.alt, "")},
+  "image3": {"url": image3.asset->url, "alt": coalesce(image3.alt, "")},
+  "image4": {"url": image4.asset->url, "alt": coalesce(image4.alt, "")},
+  "image5": {"url": image5.asset->url, "alt": coalesce(image5.alt, "")}
 `
 
+export const projectsQuery = groq`*[_type == "project"]{${baseFields}}`
+
 export const projectQuery = groq`
-  *[_type == "project" && slug.current == $slug][0]{
-    "slug": slug.current,
-    "title": name,
-    "location": coalesce(location, ""),
-    "category": coalesce(propertyType, ""),
-    "thumbnail": image1.asset->url,
-    "hero": image1.asset->url,
-    "summary": coalesce(description, ""),
-    "description": coalesce(description, "")
-  }
+  *[_type == "project" && slug.current == $slug][0]{${baseFields}}
 `
 
 export async function getProjects(): Promise<Project[]> {

--- a/src/sanity/structure.ts
+++ b/src/sanity/structure.ts
@@ -1,4 +1,0 @@
-import type {StructureResolver} from 'sanity/structure'
-
-export const structure: StructureResolver = S =>
-  S.list().title('Content').items(S.documentTypeListItems())

--- a/src/types/project.d.ts
+++ b/src/types/project.d.ts
@@ -1,16 +1,29 @@
 // Keep this as a .d.ts so it’s types-only (no runtime output)
 
-export type ProjectCategory = 'Residential' | 'Commercial';
+export interface ProjectImage {
+  url: string
+  alt: string
+}
 
 export interface Project {
-  slug: string;
-  title: string;
-  location: string;
-  category: ProjectCategory;
-  /** Path under /public, e.g. "/images/foo.jpg" */
-  thumbnail: string;
-  /** Path under /public, e.g. "/images/foo-hero.jpg" */
-  hero: string;
-  summary: string;
-  description: string;
+  slug: string
+  title: string
+  location: string
+  propertyType: string
+  bedrooms?: number
+  developer?: string
+  startingPriceAED?: number
+  sizeRange?: string
+  listingUrl?: string
+  /** First image used for previews */
+  thumbnail: string
+  /** Hero image used on detail pages */
+  hero: string
+  summary: string
+  description: string
+  image1?: ProjectImage
+  image2?: ProjectImage
+  image3?: ProjectImage
+  image4?: ProjectImage
+  image5?: ProjectImage
 }


### PR DESCRIPTION
## Summary
- expand `Project` type to match Sanity schema fields
- update GROQ queries and components to use `propertyType` and include image alt text
- drop unused custom desk structure file

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c3d5a0a8208324a66aa881707012df