### PR TITLE
chore: remove turbopack from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "dev:turbo": "next dev --turbopack",
+    "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- remove turbopack from default dev and build scripts
- add optional `dev:turbo` script for turbopack development

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: You're importing a component that needs `useState` ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c40ba065c0832488d1a2be2b7462c3