### PR TITLE
Conditionally disable Next.js image optimization in dev

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  images: { unoptimized: true }, // dev-only
+  images:
+    process.env.NODE_ENV !== 'production'
+      ? { unoptimized: true }
+      : {},
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- conditionally enable `images.unoptimized` only outside production

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot read config file / patch not recognized)
- `npm run typecheck` (fails: node_modules/csstype/index.d.ts(9708,6): error TS1010: '*/' expected.)

------
https://chatgpt.com/codex/tasks/task_e_68c40b9e84e88324bd82d03e98299fd4