### PR TITLE
fix: ensure studio page builds and add env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Environment variables
+
+Before building or deploying, copy `.env.example` to `.env.local` and provide values for:
+
+- `NEXT_PUBLIC_SANITY_PROJECT_ID`
+- `NEXT_PUBLIC_SANITY_DATASET`
+- `NEXT_PUBLIC_SANITY_API_VERSION`
+- `SANITY_READ_TOKEN` (optional for private data)
+
+On Vercel, set the same variables in your project settings.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/app/studio/[[...tool]]/page.tsx
+++ b/src/app/studio/[[...tool]]/page.tsx
@@ -1,8 +1,7 @@
+"use client"
+
 import {NextStudio} from 'next-sanity/studio'
 import config from '../../../../sanity.config'
-
-export const dynamic = 'force-static'
-export {metadata, viewport} from 'next-sanity/studio'
 
 export default function StudioPage() {
   return <NextStudio config={config} />


### PR DESCRIPTION
## Summary
- simplify studio page so it can build under React 19
- document required Sanity environment variables in README

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c411efccf08324ad942d5387ef085e