### PR TITLE
Fix Next.js 15 params and sanitize config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  images: {
-    domains: ['cdn.sanity.io'], // allow Sanity’s CDN so Image can optimize assets
-  },
-};
-
-module.exports = nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
-import type { NextConfig } from 'next';
+import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  /* config options here */
-};
+  images: {
+    domains: ['cdn.sanity.io'],
+  },
+}
 
-export default nextConfig;
+export default nextConfig

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,12 +1,13 @@
-import {defineConfig} from 'sanity'
-import {visionTool} from '@sanity/vision'
-import {structureTool} from 'sanity/structure'
-import {schemaTypes} from './sanity/schemaTypes'
+import { defineConfig } from 'sanity'
+import { visionTool } from '@sanity/vision'
+import { structureTool } from 'sanity/structure'
+import { schemaTypes } from './sanity/schemaTypes'
+import { getEnvVar } from './src/utils/env'
 
 export default defineConfig({
   name: 'default',
   title: 'Scope Hauser CMS',
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  projectId: getEnvVar('NEXT_PUBLIC_SANITY_PROJECT_ID'),
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || 'production',
   basePath: '/studio',
   plugins: [structureTool(), visionTool()],

--- a/src/app/(marketing)/projects/[slug]/page.tsx
+++ b/src/app/(marketing)/projects/[slug]/page.tsx
@@ -19,9 +19,10 @@ export async function generateStaticParams() {
 export const revalidate = 600
 
 export async function generateMetadata(
-  { params }: { params: { slug: string } }
+  { params }: { params: Promise<{ slug: string }> }
 ): Promise<Metadata> {
-  const p = await client.fetch<Project | null>(projectBySlugQuery, { slug: params.slug })
+  const { slug } = await params
+  const p = await client.fetch<Project | null>(projectBySlugQuery, { slug })
   const DEFAULT_DESC = 'Discover real estate investment opportunities and find your perfect place in the UAE.'
   return {
     title: p ? `${p.title} – Scope Hauser` : 'Project Details – Scope Hauser',
@@ -30,9 +31,10 @@ export async function generateMetadata(
 }
 
 export default async function ProjectDetailPage(
-  { params }: { params: { slug: string } }
+  { params }: { params: Promise<{ slug: string }> }
 ) {
-  const p = await client.fetch<Project | null>(projectBySlugQuery, { slug: params.slug })
+  const { slug } = await params
+  const p = await client.fetch<Project | null>(projectBySlugQuery, { slug })
   if (!p) return notFound()
 
   return (

--- a/src/app/(marketing)/projects/page.tsx
+++ b/src/app/(marketing)/projects/page.tsx
@@ -23,6 +23,7 @@ const PROJECTS_QUERY = groq/* groq */ `
   "slug": slug.current,
   title,
   location,
+  category,
   "imageUrl": image.asset->url
 }
 `;
@@ -51,6 +52,7 @@ export default function ProjectsPage() {
           slug?: string | null;
           title: string;
           location?: string | null;
+          category?: string | null;
           imageUrl?: string | null;
         }>>(PROJECTS_QUERY);
 
@@ -70,7 +72,7 @@ export default function ProjectsPage() {
               slug: safeSlug,
               title: r.title,
               location: r.location ?? '',
-              category: 'Project',
+              category: r.category ?? 'Uncategorized',
               thumbnail: r.imageUrl ?? '',
               hero: r.imageUrl ?? '',
             };

--- a/src/sanity/lib/client.ts
+++ b/src/sanity/lib/client.ts
@@ -1,8 +1,9 @@
-import { createClient } from 'next-sanity';
+import { createClient } from 'next-sanity'
+import { getEnvVar } from '@/utils/env'
 
 export const client = createClient({
-  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!,
+  projectId: getEnvVar('NEXT_PUBLIC_SANITY_PROJECT_ID'),
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || 'production',
   apiVersion: process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2025-01-01',
   useCdn: true, // public, published content over CDN
-});
+})

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -6,6 +6,7 @@ export const projectsQuery = groq`
     "slug": slug.current,
     title,
     location,
+    category,
     "imageUrl": image.asset->url
   }
 `
@@ -15,6 +16,7 @@ export const projectBySlugQuery = groq`
     "slug": slug.current,
     title,
     location,
+    category,
     "imageUrl": image.asset->url
   }
 `

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,7 @@
+export function getEnvVar(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+  return value
+}


### PR DESCRIPTION
## Summary
- adapt dynamic project route to Next.js 15 async `params`
- unify Next.js config in TypeScript with Sanity CDN image domain
- validate required Sanity env vars and expose project categories for filtering

## Testing
- `npm run check`
- `NEXT_PUBLIC_SANITY_PROJECT_ID=demo NEXT_PUBLIC_SANITY_DATASET=production npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c551d2fd408324b09dd8636320291a